### PR TITLE
Fix TypeScript validation errors and adjust Vite React setup

### DIFF
--- a/ashes-asset-studio/src/main.tsx
+++ b/ashes-asset-studio/src/main.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
-import App from './App.tsx'
+import App from './App'
 import './index.css'
 
 ReactDOM.createRoot(document.getElementById('root')!).render(

--- a/ashes-asset-studio/src/utils/ajv.ts
+++ b/ashes-asset-studio/src/utils/ajv.ts
@@ -1,13 +1,14 @@
-import Ajv, { DefinedError } from "ajv";
+import Ajv from "ajv";
 import addFormats from "ajv-formats";
 import { AllSchemas } from "../schemas";
+import type { ErrorObject } from "ajv";
 
 export const ajv = new Ajv({ allErrors: true, strict: true, allowUnionTypes: true });
 addFormats(ajv);
 AllSchemas.forEach(s => ajv.addSchema(s));
 
 export type ValidationError = { path: string; message: string };
-export function toFriendlyErrors(errors: DefinedError[] | null | undefined): ValidationError[] {
+export function toFriendlyErrors(errors: ErrorObject[] | null | undefined): ValidationError[] {
   if (!errors) return [];
   return errors.map(e => ({ path: e.instancePath || "/", message: e.message || "Invalid" }));
 }

--- a/ashes-asset-studio/vite.config.ts
+++ b/ashes-asset-studio/vite.config.ts
@@ -1,6 +1,8 @@
 import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react'
 
 export default defineConfig({
-  plugins: [react()],
+  esbuild: {
+    jsx: 'automatic',
+    jsxImportSource: 'react',
+  },
 })


### PR DESCRIPTION
## Summary
- update the Ajv helper to use type-only imports and accept general ErrorObject arrays
- fix the main entry import so it no longer requires the .tsx extension under strict module settings
- configure Vite to rely on esbuild's automatic JSX handling instead of the missing React plugin

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68deb9261248832195db64bafdbef4fd