### PR TITLE
Fix Ajv error typing for friendly error conversion

### DIFF
--- a/ashes-asset-studio/src/utils/ajv.ts
+++ b/ashes-asset-studio/src/utils/ajv.ts
@@ -8,7 +8,9 @@ addFormats(ajv);
 AllSchemas.forEach(s => ajv.addSchema(s));
 
 export type ValidationError = { path: string; message: string };
-export function toFriendlyErrors(errors: ErrorObject[] | null | undefined): ValidationError[] {
+type AjvError = ErrorObject<string, Record<string, unknown>, unknown>;
+
+export function toFriendlyErrors(errors: readonly AjvError[] | null | undefined): ValidationError[] {
   if (!errors) return [];
   return errors.map(e => ({ path: e.instancePath || "/", message: e.message || "Invalid" }));
 }


### PR DESCRIPTION
## Summary
- add a dedicated Ajv error alias so the friendly error helper accepts the stricter type emitted by Ajv
- keep the helper API unchanged so existing components continue to work

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68debad1f9588321bf75326c30c86832