### PR TITLE
Use Ajv DefinedError for friendly errors

### DIFF
--- a/ashes-asset-studio/src/components/DynamicForm.tsx
+++ b/ashes-asset-studio/src/components/DynamicForm.tsx
@@ -23,7 +23,7 @@ export function MonsterFormView({ onValid }:{ onValid:(val: MonsterForm)=>void }
     const v = ajv.getSchema("MonsterStatCard");
     if(!v) return;
     const ok = v(data as any);
-    if(!ok) setErrors(toFriendlyErrors(v.errors).map(e=>`${e.path}: ${e.message}`));
+    if(!ok) setErrors(toFriendlyErrors(v.errors as Parameters<typeof toFriendlyErrors>[0]).map(e=>`${e.path}: ${e.message}`));
     else { setErrors([]); onValid(data); }
   };
 

--- a/ashes-asset-studio/src/components/JsonPane.tsx
+++ b/ashes-asset-studio/src/components/JsonPane.tsx
@@ -11,7 +11,7 @@ export function JsonPane({ schemaId, initial, onValid }:{ schemaId: string; init
       const v = ajv.getSchema(schemaId);
       if(!v) throw new Error(`Schema not found: ${schemaId}`);
       const ok = v(val);
-      if(!ok){ setErrors(toFriendlyErrors(v.errors).map(e=>`${e.path}: ${e.message}`)); return; }
+      if(!ok){ setErrors(toFriendlyErrors(v.errors as Parameters<typeof toFriendlyErrors>[0]).map(e=>`${e.path}: ${e.message}`)); return; }
       setErrors([]); onValid(val);
     }catch(e:any){ setErrors([e.message]); }
   },[text,schemaId,onValid]);

--- a/ashes-asset-studio/src/utils/ajv.ts
+++ b/ashes-asset-studio/src/utils/ajv.ts
@@ -1,16 +1,15 @@
 import Ajv from "ajv";
+import type { DefinedError } from "ajv";
 import addFormats from "ajv-formats";
 import { AllSchemas } from "../schemas";
-import type { ErrorObject } from "ajv";
 
 export const ajv = new Ajv({ allErrors: true, strict: true, allowUnionTypes: true });
 addFormats(ajv);
 AllSchemas.forEach(s => ajv.addSchema(s));
 
 export type ValidationError = { path: string; message: string };
-type AjvError = ErrorObject<string, Record<string, unknown>, unknown>;
 
-export function toFriendlyErrors(errors: readonly AjvError[] | null | undefined): ValidationError[] {
+export function toFriendlyErrors(errors: readonly DefinedError[] | null | undefined): ValidationError[] {
   if (!errors) return [];
   return errors.map(e => ({ path: e.instancePath || "/", message: e.message || "Invalid" }));
 }


### PR DESCRIPTION
## Summary
- replace the Ajv error alias with the library's DefinedError type in the validation utilities
- adjust the friendly error helper signature and call sites to align with the DefinedError type

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68debe7389048321a3ce552cf68ebc3a