### PR TITLE
Scaffold initial Asset Studio application

### DIFF
--- a/ashes-asset-studio/.eslintrc.cjs
+++ b/ashes-asset-studio/.eslintrc.cjs
@@ -1,0 +1,27 @@
+module.exports = {
+  root: true,
+  env: {
+    browser: true,
+    es2021: true
+  },
+  extends: [
+    "eslint:recommended",
+    "plugin:@typescript-eslint/recommended",
+    "plugin:react-hooks/recommended",
+    "prettier"
+  ],
+  parser: "@typescript-eslint/parser",
+  parserOptions: {
+    ecmaVersion: "latest",
+    sourceType: "module"
+  },
+  plugins: ["@typescript-eslint"],
+  rules: {
+    "react-hooks/exhaustive-deps": "warn"
+  },
+  settings: {
+    react: {
+      version: "detect"
+    }
+  }
+};

--- a/ashes-asset-studio/.gitignore
+++ b/ashes-asset-studio/.gitignore
@@ -1,0 +1,8 @@
+node_modules
+.dist
+.vite
+.idea
+.DS_Store
+dist
+npm-debug.log*
+.env.local

--- a/ashes-asset-studio/README.md
+++ b/ashes-asset-studio/README.md
@@ -1,0 +1,32 @@
+# Ashes of Verdun — Asset Studio
+
+A single-page React + TypeScript + TailwindCSS tool for crafting, validating, and archiving card assets for the Ashes of Verdun tabletop project.
+
+## Getting Started
+
+```bash
+npm install
+npm run dev
+```
+
+The app runs at `http://localhost:5173`. Card data persists in `localStorage` per browser profile.
+
+## Available Scripts
+
+- `npm run dev` — Start the Vite development server.
+- `npm run build` — Type-check with `tsc` and output a production build.
+- `npm run preview` — Preview the production build locally.
+- `npm run lint` — Lint TypeScript/React sources via ESLint.
+
+## Adding New Asset Types
+
+1. Author an AJV-compatible JSON schema in `src/schemas/<type>.schema.json` and register it inside `src/schemas/index.ts`.
+2. Extend `AssetType` in `src/schemas/types.ts`.
+3. Append a form definition in `src/utils/formConfig.ts` (or rely on JSON mode until the bespoke form is ready).
+4. Add rendering logic in `CardPreview` as desired for the new asset type.
+
+## Project Pillars
+
+- Cohesive Ashen brand skin across previews.
+- Strict schema validation via AJV for both form and JSON modes.
+- Local persistence with graceful empty states and accessible UI patterns.

--- a/ashes-asset-studio/index.html
+++ b/ashes-asset-studio/index.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Ashes of Verdun — Asset Studio</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Cinzel:wght@600;700&family=Inter:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
+  </head>
+  <body class="bg-slate-950 text-slate-100">
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/ashes-asset-studio/package.json
+++ b/ashes-asset-studio/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "ashes-asset-studio",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview",
+    "lint": "eslint . --ext ts,tsx"
+  },
+  "dependencies": {
+    "ajv": "^8.12.0",
+    "ajv-formats": "^2.1.1",
+    "clsx": "^2.1.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "date-fns": "^2.30.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.21",
+    "@types/react-dom": "^18.2.7",
+    "@typescript-eslint/eslint-plugin": "^6.7.2",
+    "@typescript-eslint/parser": "^6.7.2",
+    "autoprefixer": "^10.4.16",
+    "eslint": "^8.50.0",
+    "eslint-config-prettier": "^9.0.0",
+    "eslint-plugin-react-hooks": "^4.6.0",
+    "postcss": "^8.4.31",
+    "tailwindcss": "^3.3.3",
+    "typescript": "^5.2.2",
+    "vite": "^4.4.11",
+    "@vitejs/plugin-react": "^4.0.3"
+  }
+}

--- a/ashes-asset-studio/postcss.config.cjs
+++ b/ashes-asset-studio/postcss.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/ashes-asset-studio/public/favicon.svg
+++ b/ashes-asset-studio/public/favicon.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <defs>
+    <linearGradient id="ashGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#f59e0b" />
+      <stop offset="100%" stop-color="#1f2937" />
+    </linearGradient>
+  </defs>
+  <rect width="64" height="64" rx="12" fill="#0f172a" />
+  <path
+    d="M32 10l12 12-8 8 8 8-12 12-12-12 8-8-8-8z"
+    fill="url(#ashGradient)"
+    stroke="#fbbf24"
+    stroke-width="2"
+    stroke-linejoin="round"
+  />
+</svg>

--- a/ashes-asset-studio/src/App.tsx
+++ b/ashes-asset-studio/src/App.tsx
@@ -1,0 +1,47 @@
+import { AssetProvider } from "./context/AssetContext";
+import { ShellLayout } from "./components/ShellLayout";
+import { Stepper } from "./components/Stepper";
+import { TypePicker } from "./components/TypePicker";
+import { ModeSwitcher } from "./components/ModeSwitcher";
+import { DynamicForm } from "./components/DynamicForm";
+import { JsonPane } from "./components/JsonPane";
+import { ValidationPanel } from "./components/ValidationPanel";
+import { ActionBar } from "./components/ActionBar";
+import { LibraryPanel } from "./components/LibraryPanel";
+import { CardPreview } from "./components/CardPreview";
+import { useAsset } from "./context/useAsset";
+
+function Workspace() {
+  const {
+    state: {
+      editor: { mode, step }
+    }
+  } = useAsset();
+
+  return (
+    <div className="space-y-6">
+      <Stepper currentStep={step} />
+      <div className="grid gap-6 lg:grid-cols-[minmax(0,2fr)_minmax(0,1fr)]">
+        <section className="space-y-6 rounded-xl border border-slate-800 bg-slate-950/70 p-6 shadow-inner shadow-amber-500/10">
+          <TypePicker />
+          <ModeSwitcher />
+          {mode === "form" ? <DynamicForm /> : <JsonPane />}
+          <ValidationPanel />
+          <ActionBar />
+        </section>
+        <LibraryPanel />
+      </div>
+      <CardPreview />
+    </div>
+  );
+}
+
+export default function App() {
+  return (
+    <AssetProvider>
+      <ShellLayout>
+        <Workspace />
+      </ShellLayout>
+    </AssetProvider>
+  );
+}

--- a/ashes-asset-studio/src/components/ActionBar.tsx
+++ b/ashes-asset-studio/src/components/ActionBar.tsx
@@ -1,0 +1,43 @@
+import { createRecord, useAssetContext } from "../context/AssetContext";
+
+export function ActionBar() {
+  const {
+    state: {
+      editor: { selectedType, draft, isValid }
+    },
+    dispatch
+  } = useAssetContext();
+
+  const canSave = Boolean(selectedType && isValid && draft);
+
+  const handleSave = () => {
+    if (!selectedType || !draft) return;
+    const record = createRecord(selectedType, draft);
+    dispatch({ type: "addRecord", payload: { record } });
+  };
+
+  return (
+    <div className="flex flex-wrap items-center justify-between gap-3">
+      <div className="flex gap-2">
+        <button
+          type="button"
+          onClick={handleSave}
+          disabled={!canSave}
+          className="rounded-md bg-amber-500 px-4 py-2 text-sm font-semibold text-slate-950 transition disabled:cursor-not-allowed disabled:bg-slate-700 disabled:text-slate-400"
+        >
+          Save to Library
+        </button>
+        <button
+          type="button"
+          onClick={() => dispatch({ type: "reset" })}
+          className="rounded-md border border-slate-700 px-3 py-2 text-sm text-slate-200 transition hover:border-slate-500 hover:text-amber-100"
+        >
+          Reset
+        </button>
+      </div>
+      <p className="text-xs text-slate-400">
+        Saving locks validation for preview; edit again by selecting the asset from the library.
+      </p>
+    </div>
+  );
+}

--- a/ashes-asset-studio/src/components/CardPreview.tsx
+++ b/ashes-asset-studio/src/components/CardPreview.tsx
@@ -1,0 +1,70 @@
+import { clsx } from "clsx";
+import { useAsset } from "../context/useAsset";
+import { AssetType } from "../schemas/types";
+
+const labelMap: Record<AssetType, string> = {
+  monsterStat: "Monster Stat Card",
+  monsterAbility: "Monster Ability Card",
+  heroAbility: "Hero Ability Card",
+  equipment: "Equipment Card",
+  consumable: "Consumable Card",
+  burden: "Burden Resolution Card",
+  ash: "Ash Surge Card"
+};
+
+export function CardPreview() {
+  const {
+    state: {
+      editor: { selectedType, draft }
+    }
+  } = useAsset();
+
+  if (!selectedType || !draft) {
+    return (
+      <section className="mt-6 rounded-2xl border border-slate-800 bg-slate-950/60 p-6 text-center text-sm text-slate-400">
+        Save an asset to see the Ashen card frame come to life.
+      </section>
+    );
+  }
+
+  const name = (draft as Record<string, unknown>).name ?? "Unnamed Asset";
+  const subtitle = labelMap[selectedType];
+
+  return (
+    <section className="mt-6">
+      <header className="mb-3 flex items-center justify-between">
+        <h2 className="text-sm font-semibold uppercase text-slate-200">Preview</h2>
+        <span className="text-xs text-slate-500">Shared Ashen brand across asset types</span>
+      </header>
+      <article className="relative mx-auto max-w-md overflow-hidden rounded-3xl border border-amber-500/30 bg-gradient-to-br from-slate-950 via-slate-900 to-amber-950/20 p-6 shadow-[0_0_40px_rgba(255,176,0,0.15)]">
+        <div className="flex items-baseline justify-between text-amber-200">
+          <h3 className="font-display text-2xl uppercase tracking-[0.2em]">{String(name)}</h3>
+          <span className="rounded-full border border-amber-500/40 px-3 py-1 text-xs uppercase tracking-[0.3em] text-amber-300">
+            {subtitle}
+          </span>
+        </div>
+        <div className="mt-4 rounded-lg border border-slate-800/70 bg-slate-950/80 p-4 text-left text-sm text-slate-200">
+          {Object.entries(draft as Record<string, unknown>).map(([key, value]) => {
+            const displayValue = Array.isArray(value)
+              ? value.join(", ")
+              : value && typeof value === "object"
+                ? JSON.stringify(value, null, 0)
+                : value ?? "—";
+            return (
+              <div
+                key={key}
+                className={clsx(
+                  "flex justify-between border-b border-slate-800/40 py-1 text-xs uppercase tracking-wide",
+                  key === "traits" && "items-start"
+                )}
+              >
+                <span className="text-slate-400">{key}</span>
+                <span className="text-amber-100">{String(displayValue)}</span>
+              </div>
+            );
+          })}
+        </div>
+      </article>
+    </section>
+  );
+}

--- a/ashes-asset-studio/src/components/DynamicForm.tsx
+++ b/ashes-asset-studio/src/components/DynamicForm.tsx
@@ -1,0 +1,121 @@
+import { ChangeEvent } from "react";
+import { fieldConfigMap, type FieldConfig } from "../utils/formConfig";
+import { useAsset } from "../context/useAsset";
+import { AssetType } from "../schemas/types";
+
+export function DynamicForm() {
+  const {
+    state: {
+      editor: { selectedType, draft }
+    },
+    dispatch
+  } = useAsset();
+
+  if (!selectedType) {
+    return (
+      <div className="rounded-lg border border-dashed border-slate-700 bg-slate-950/40 p-6 text-sm text-slate-400">
+        Choose an asset type to reveal its tailored form.
+      </div>
+    );
+  }
+
+  const fields = fieldConfigMap[selectedType as AssetType] ?? [];
+
+  if (fields.length === 0) {
+    return (
+      <div className="rounded-lg border border-amber-500/40 bg-amber-500/10 p-6 text-sm text-amber-100">
+        Form scaffolding for this asset type is under construction. Use JSON mode meanwhile.
+      </div>
+    );
+  }
+
+  const handleChange = (
+    event: ChangeEvent<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>,
+    field: FieldConfig
+  ) => {
+    const { value } = event.target;
+    const parsedValue = field.input === "number" && value !== "" ? Number(value) : value;
+    const finalValue = field.transform ? field.transform(String(parsedValue)) : parsedValue;
+    dispatch({ type: "updateDraft", payload: { name: field.name, value: finalValue } });
+  };
+
+  return (
+    <section aria-labelledby="dynamic-form-heading" className="space-y-3">
+      <div>
+        <h2 id="dynamic-form-heading" className="text-sm font-semibold uppercase text-slate-200">
+          3. Complete Required Fields
+        </h2>
+        <p className="mt-1 text-xs text-slate-400">
+          Validation fires as you type. Hover labels for contextual hints.
+        </p>
+      </div>
+      <form className="grid gap-4 md:grid-cols-2">
+        {fields.map((field) => {
+          let fieldValue = (draft ?? {})[field.name] ?? "";
+          if (field.input === "textarea" && Array.isArray(fieldValue)) {
+            fieldValue = fieldValue.join("\n");
+          }
+          if (field.input === "select") {
+            return (
+              <label key={field.name} className="flex flex-col gap-2 text-sm">
+                <span className="text-xs font-semibold uppercase text-slate-300">{field.label}</span>
+                <select
+                  value={String(fieldValue)}
+                  onChange={(event) => handleChange(event, field)}
+                  className="rounded-md border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-slate-100 focus:border-amber-400 focus:outline-none focus:ring-2 focus:ring-amber-400/30"
+                >
+                  <option value="" disabled>
+                    Select an option
+                  </option>
+                  {field.options.map((option) => (
+                    <option key={option.value} value={option.value}>
+                      {option.label}
+                    </option>
+                  ))}
+                </select>
+                {field.help && <span className="text-[11px] text-slate-500">{field.help}</span>}
+              </label>
+            );
+          }
+
+          const inputProps = {
+            value: String(fieldValue),
+            onChange: (event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) =>
+              handleChange(event, field),
+            placeholder: field.placeholder,
+            className:
+              "w-full rounded-md border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-slate-100 placeholder:text-slate-500 focus:border-amber-400 focus:outline-none focus:ring-2 focus:ring-amber-400/30"
+          } as const;
+
+          if (field.input === "number") {
+            return (
+              <label key={field.name} className="flex flex-col gap-2 text-sm">
+                <span className="text-xs font-semibold uppercase text-slate-300">{field.label}</span>
+                <input type="number" {...inputProps} />
+                {field.help && <span className="text-[11px] text-slate-500">{field.help}</span>}
+              </label>
+            );
+          }
+
+          if (field.input === "textarea") {
+            return (
+              <label key={field.name} className="flex flex-col gap-2 text-sm md:col-span-2">
+                <span className="text-xs font-semibold uppercase text-slate-300">{field.label}</span>
+                <textarea rows={3} {...inputProps} />
+                {field.help && <span className="text-[11px] text-slate-500">{field.help}</span>}
+              </label>
+            );
+          }
+
+          return (
+            <label key={field.name} className="flex flex-col gap-2 text-sm">
+              <span className="text-xs font-semibold uppercase text-slate-300">{field.label}</span>
+              <input type="text" {...inputProps} />
+              {field.help && <span className="text-[11px] text-slate-500">{field.help}</span>}
+            </label>
+          );
+        })}
+      </form>
+    </section>
+  );
+}

--- a/ashes-asset-studio/src/components/JsonPane.tsx
+++ b/ashes-asset-studio/src/components/JsonPane.tsx
@@ -1,0 +1,66 @@
+import { useEffect } from "react";
+import { useAsset } from "../context/useAsset";
+import { validateAsset } from "../utils/ajv";
+
+export function JsonPane() {
+  const {
+    state: {
+      editor: { selectedType, jsonDraft }
+    },
+    dispatch
+  } = useAsset();
+
+  useEffect(() => {
+    if (!selectedType) {
+      dispatch({ type: "setValidation", payload: { valid: false, issues: [] } });
+      return;
+    }
+
+    if (!jsonDraft.trim()) {
+      dispatch({ type: "setValidation", payload: { valid: false, issues: [] } });
+      return;
+    }
+
+    try {
+      const parsed = JSON.parse(jsonDraft);
+      const validation = validateAsset(selectedType, parsed);
+      dispatch({ type: "setValidation", payload: validation });
+      if (validation.valid) {
+        dispatch({ type: "setDraft", payload: { draft: parsed } });
+      }
+    } catch (error) {
+      dispatch({
+        type: "setValidation",
+        payload: {
+          valid: false,
+          issues: [
+            {
+              field: "json",
+              message: error instanceof Error ? error.message : "Invalid JSON"
+            }
+          ]
+        }
+      });
+    }
+  }, [jsonDraft, selectedType, dispatch]);
+
+  return (
+    <section aria-labelledby="json-pane-heading" className="space-y-2">
+      <div>
+        <h2 id="json-pane-heading" className="text-sm font-semibold uppercase text-slate-200">
+          3. Paste Asset JSON
+        </h2>
+        <p className="mt-1 text-xs text-slate-400">
+          Schema validation runs automatically—no manual submit button required.
+        </p>
+      </div>
+      <textarea
+        value={jsonDraft}
+        onChange={(event) => dispatch({ type: "setJsonDraft", payload: { value: event.target.value } })}
+        className="h-72 w-full rounded-lg border border-slate-800 bg-slate-950 px-4 py-3 font-mono text-xs text-amber-100 focus:border-amber-400 focus:outline-none focus:ring-2 focus:ring-amber-500/30"
+        placeholder="{\n  \"id\": \"...\",\n  \"name\": \"...\"\n}"
+        spellCheck={false}
+      />
+    </section>
+  );
+}

--- a/ashes-asset-studio/src/components/LibraryPanel.tsx
+++ b/ashes-asset-studio/src/components/LibraryPanel.tsx
@@ -1,0 +1,63 @@
+import { formatRelative } from "date-fns";
+import { useAsset } from "../context/useAsset";
+import { AssetRecord } from "../context/types";
+
+export function LibraryPanel() {
+  const {
+    state: {
+      library: { records, selectedId }
+    },
+    dispatch
+  } = useAsset();
+
+  const handleSelect = (record: AssetRecord) => {
+    dispatch({ type: "selectRecord", payload: { id: record.id } });
+  };
+
+  return (
+    <aside className="flex h-full flex-col gap-4 rounded-xl border border-slate-800 bg-slate-950/70 p-4">
+      <header className="space-y-1">
+        <h2 className="text-sm font-semibold uppercase text-slate-200">Library</h2>
+        <p className="text-xs text-slate-400">Saved assets persist locally via browser storage.</p>
+      </header>
+      <div className="flex-1 space-y-2 overflow-y-auto pr-1">
+        {records.length === 0 ? (
+          <p className="rounded-lg border border-dashed border-slate-700 bg-slate-950/40 p-4 text-xs text-slate-400">
+            Save your first asset to seed the Ash archives.
+          </p>
+        ) : (
+          records.map((record) => {
+            const isActive = record.id === selectedId;
+            let relativeTime = "just now";
+            try {
+              relativeTime = formatRelative(new Date(record.updatedAt), new Date());
+            } catch (error) {
+              console.warn("Failed to format timestamp", error);
+            }
+            return (
+              <button
+                key={record.id}
+                type="button"
+                onClick={() => handleSelect(record)}
+                className={`w-full rounded-lg border px-3 py-2 text-left text-sm transition focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 ${
+                  isActive
+                    ? "border-amber-500/70 bg-amber-500/10 text-amber-100"
+                    : "border-slate-800 bg-slate-950/60 text-slate-200 hover:border-amber-400/60 hover:text-amber-100"
+                }`}
+              >
+                <span className="block text-xs font-semibold uppercase tracking-wide">
+                  {record.data && typeof record.data === "object" && "name" in record.data
+                    ? String((record.data as { name?: string }).name ?? record.id)
+                    : record.id}
+                </span>
+                <span className="mt-1 block text-[11px] text-slate-400">
+                  {record.type} · Saved {relativeTime}
+                </span>
+              </button>
+            );
+          })
+        )}
+      </div>
+    </aside>
+  );
+}

--- a/ashes-asset-studio/src/components/ModeSwitcher.tsx
+++ b/ashes-asset-studio/src/components/ModeSwitcher.tsx
@@ -1,0 +1,49 @@
+import { useAsset } from "../context/useAsset";
+
+export function ModeSwitcher() {
+  const {
+    state: {
+      editor: { mode }
+    },
+    dispatch
+  } = useAsset();
+
+  const modes: { value: "form" | "json"; label: string; description: string }[] = [
+    { value: "form", label: "Form Mode", description: "Guided fields with inline validation." },
+    { value: "json", label: "JSON Mode", description: "Paste raw JSON and validate via schema." }
+  ];
+
+  return (
+    <section aria-labelledby="mode-switcher-heading" className="space-y-2">
+      <div className="flex items-baseline justify-between gap-4">
+        <div>
+          <h2 id="mode-switcher-heading" className="text-sm font-semibold uppercase text-slate-200">
+            2. Choose Input Mode
+          </h2>
+          <p className="mt-1 text-xs text-slate-400">Switch anytime—drafts persist while you experiment.</p>
+        </div>
+      </div>
+      <div className="flex flex-wrap gap-3">
+        {modes.map((entry) => {
+          const isActive = entry.value === mode;
+          return (
+            <button
+              key={entry.value}
+              type="button"
+              onClick={() => dispatch({ type: "setMode", payload: { mode: entry.value } })}
+              aria-pressed={isActive}
+              className={`rounded-lg border px-4 py-2 text-left transition focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 ${
+                isActive
+                  ? "border-amber-500/80 bg-amber-500/10 text-amber-100"
+                  : "border-slate-800 bg-slate-950/60 text-slate-200 hover:border-amber-400/60 hover:text-amber-100"
+              }`}
+            >
+              <span className="block text-xs font-semibold uppercase tracking-wide">{entry.label}</span>
+              <span className="mt-1 block text-[11px] text-slate-400">{entry.description}</span>
+            </button>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/ashes-asset-studio/src/components/ShellLayout.tsx
+++ b/ashes-asset-studio/src/components/ShellLayout.tsx
@@ -1,0 +1,20 @@
+import { type ReactNode } from "react";
+
+export function ShellLayout({ children }: { children: ReactNode }) {
+  return (
+    <div className="min-h-screen bg-slate-950 text-slate-100">
+      <header className="border-b border-slate-800 bg-slate-950/80 backdrop-blur">
+        <div className="mx-auto flex max-w-6xl items-center justify-between px-6 py-4">
+          <div>
+            <p className="text-[10px] uppercase tracking-[0.4em] text-amber-500/70">Ashes of Verdun</p>
+            <h1 className="font-display text-xl uppercase tracking-[0.3em] text-amber-100">
+              Asset Studio
+            </h1>
+          </div>
+          <span className="text-xs text-slate-500">Craft, validate, and archive every card asset.</span>
+        </div>
+      </header>
+      <main className="mx-auto flex max-w-6xl flex-col gap-6 px-6 py-8">{children}</main>
+    </div>
+  );
+}

--- a/ashes-asset-studio/src/components/Stepper.tsx
+++ b/ashes-asset-studio/src/components/Stepper.tsx
@@ -1,0 +1,30 @@
+import { clsx } from "clsx";
+
+const steps = ["Type", "Mode", "Fill / Paste", "Validate", "Preview"] as const;
+
+export function Stepper({ currentStep }: { currentStep: number }) {
+  return (
+    <ol className="flex flex-wrap items-center gap-2 text-xs uppercase tracking-[0.2em] text-slate-400">
+      {steps.map((label, index) => {
+        const stepIndex = index;
+        const isActive = currentStep >= stepIndex;
+        return (
+          <li
+            key={label}
+            className={clsx(
+              "flex items-center gap-2 rounded-full border px-3 py-1 transition",
+              isActive
+                ? "border-amber-500/60 bg-amber-500/10 text-amber-200"
+                : "border-slate-700/60 bg-slate-900 text-slate-500"
+            )}
+          >
+            <span className="flex size-5 items-center justify-center rounded-full bg-slate-800 font-semibold text-[0.65rem] text-slate-200">
+              {index + 1}
+            </span>
+            <span>{label}</span>
+          </li>
+        );
+      })}
+    </ol>
+  );
+}

--- a/ashes-asset-studio/src/components/TypePicker.tsx
+++ b/ashes-asset-studio/src/components/TypePicker.tsx
@@ -1,0 +1,89 @@
+import { AssetType } from "../schemas/types";
+import { useAsset } from "../context/useAsset";
+
+const typeOptions: { value: AssetType; label: string; description: string }[] = [
+  {
+    value: "monsterStat",
+    label: "Monster Stat Card",
+    description: "Core monster statline, traits, and scaling."
+  },
+  {
+    value: "monsterAbility",
+    label: "Monster Ability Card",
+    description: "Initiative and scripted actions for encounters."
+  },
+  {
+    value: "heroAbility",
+    label: "Hero Ability Card",
+    description: "Class skills with timing, outcomes, and costs."
+  },
+  {
+    value: "equipment",
+    label: "Item / Equipment",
+    description: "Weapons, armor, and relics bearing perks and drawbacks."
+  },
+  {
+    value: "consumable",
+    label: "Consumable",
+    description: "Single-use brews, bandages, or alchemical aids."
+  },
+  {
+    value: "burden",
+    label: "Burden Resolution",
+    description: "Afflictions and virtues that shape a hero's psyche."
+  },
+  {
+    value: "ash",
+    label: "Ash Surge Card",
+    description: "Optional module for Ash escalation and surge boons."
+  }
+];
+
+export function TypePicker() {
+  const {
+    state: {
+      editor: { selectedType }
+    },
+    dispatch
+  } = useAsset();
+
+  return (
+    <section aria-labelledby="type-picker-heading" className="space-y-3">
+      <div>
+        <h2 id="type-picker-heading" className="text-sm font-semibold uppercase text-slate-200">
+          1. Choose Asset Type
+        </h2>
+        <p className="mt-1 text-xs text-slate-400">
+          Assets share a cohesive Ashen brand but expose type-specific fields.
+        </p>
+      </div>
+      <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+        {typeOptions.map((option) => {
+          const isActive = option.value === selectedType;
+          return (
+            <button
+              key={option.value}
+              type="button"
+              onClick={() =>
+                dispatch({ type: "setType", payload: { type: option.value } })
+              }
+              aria-pressed={isActive}
+              className={`rounded-xl border px-4 py-3 text-left transition focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 ${
+                isActive
+                  ? "border-amber-500/80 bg-amber-500/10 text-amber-100 shadow-[0_0_0_1px_rgba(240,171,0,0.25)]"
+                  : "border-slate-800 bg-slate-950/60 text-slate-200 hover:border-amber-500/50 hover:bg-slate-900"
+              }`}
+            >
+              <span className="block text-xs font-semibold uppercase tracking-wide">
+                {option.label}
+              </span>
+              <span className="mt-2 block text-[11px] text-slate-400">
+                {option.description}
+              </span>
+            </button>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/ashes-asset-studio/src/components/ValidationPanel.tsx
+++ b/ashes-asset-studio/src/components/ValidationPanel.tsx
@@ -1,0 +1,34 @@
+import { useAsset } from "../context/useAsset";
+
+export function ValidationPanel() {
+  const {
+    state: {
+      editor: { validationErrors, isValid }
+    }
+  } = useAsset();
+
+  if (validationErrors.length === 0) {
+    return (
+      <div className="rounded-lg border border-slate-800 bg-slate-950/70 p-4 text-xs text-slate-300">
+        {isValid
+          ? "Validation succeeded. Save to add this asset to the Ash library."
+          : "Complete the form or paste JSON to begin validation."}
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-lg border border-rose-700/70 bg-rose-900/20 p-4">
+      <p className="text-xs font-semibold uppercase tracking-wide text-rose-200">
+        Validation Issues
+      </p>
+      <ul className="mt-2 space-y-1 text-xs text-rose-100">
+        {validationErrors.map((issue, index) => (
+          <li key={`${issue.field}-${index}`}>
+            <span className="font-semibold">{issue.field}:</span> {issue.message}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/ashes-asset-studio/src/context/AssetContext.tsx
+++ b/ashes-asset-studio/src/context/AssetContext.tsx
@@ -1,0 +1,234 @@
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useMemo,
+  useReducer,
+  type Dispatch,
+  type ReactNode
+} from "react";
+import {
+  AssetAction,
+  AssetRecord,
+  EditorState,
+  LibraryState
+} from "./types";
+import { AssetType } from "../schemas/types";
+import { loadLibrary, persistLibrary } from "../utils/storage";
+import { validateAsset } from "../utils/ajv";
+import { defaultMonsterStat } from "../data/defaultAssets";
+
+const initialEditor: EditorState = {
+  step: 0,
+  selectedType: null,
+  mode: "form",
+  draft: null,
+  jsonDraft: "",
+  validationErrors: [],
+  isValid: false
+};
+
+const initialLibrary: LibraryState = {
+  records: [],
+  filters: {
+    search: "",
+    types: [],
+    sort: "updatedDesc"
+  },
+  selectedId: null
+};
+
+type State = {
+  editor: EditorState;
+  library: LibraryState;
+};
+
+const AssetContext = createContext<{
+  state: State;
+  dispatch: Dispatch<AssetAction>;
+}>({
+  state: { editor: initialEditor, library: initialLibrary },
+  dispatch: () => {
+    throw new Error("AssetContext used outside provider");
+  }
+});
+
+function generateId(): string {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID();
+  }
+
+  const template = "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx";
+  return template.replace(/[xy]/g, (char) => {
+    const rand = (Math.random() * 16) | 0;
+    const value = char === "x" ? rand : (rand & 0x3) | 0x8;
+    return value.toString(16);
+  });
+}
+
+function reducer(state: State, action: AssetAction): State {
+  switch (action.type) {
+    case "setType": {
+      return {
+        editor: {
+          ...state.editor,
+          selectedType: action.payload.type,
+          step: 1,
+          draft: { id: generateId() },
+          jsonDraft: "",
+          validationErrors: [],
+          isValid: false
+        },
+        library: state.library
+      };
+    }
+    case "setMode": {
+      return {
+        editor: {
+          ...state.editor,
+          mode: action.payload.mode,
+          step: Math.max(state.editor.step, 2)
+        },
+        library: state.library
+      };
+    }
+    case "setStep": {
+      return {
+        editor: { ...state.editor, step: action.payload.step },
+        library: state.library
+      };
+    }
+    case "updateDraft": {
+      const baseDraft = state.editor.draft ?? { id: generateId() };
+      const draft = {
+        ...baseDraft,
+        [action.payload.name]: action.payload.value
+      };
+      const type = state.editor.selectedType;
+      let validation = { valid: false, issues: [] as { field: string; message: string }[] };
+      if (type) {
+        validation = validateAsset(type, draft);
+      }
+      return {
+        editor: {
+          ...state.editor,
+          draft,
+          validationErrors: validation.issues,
+          isValid: validation.valid,
+          step: Math.max(state.editor.step, 3)
+        },
+        library: state.library
+      };
+    }
+    case "setDraft": {
+      return {
+        editor: { ...state.editor, draft: action.payload.draft },
+        library: state.library
+      };
+    }
+    case "setJsonDraft": {
+      return {
+        editor: { ...state.editor, jsonDraft: action.payload.value },
+        library: state.library
+      };
+    }
+    case "setValidation": {
+      return {
+        editor: {
+          ...state.editor,
+          validationErrors: action.payload.issues,
+          isValid: action.payload.valid,
+          step:
+            action.payload.issues.length > 0 || action.payload.valid
+              ? Math.max(state.editor.step, 3)
+              : state.editor.step
+        },
+        library: state.library
+      };
+    }
+    case "addRecord": {
+      const records = [...state.library.records];
+      const existingIndex = records.findIndex((r) => r.id === action.payload.record.id);
+      if (existingIndex >= 0) {
+        records[existingIndex] = action.payload.record;
+      } else {
+        records.unshift(action.payload.record);
+      }
+      return {
+        editor: {
+          ...state.editor,
+          step: 4,
+          draft: action.payload.record.data as Record<string, unknown>,
+          isValid: true
+        },
+        library: {
+          ...state.library,
+          records
+        }
+      };
+    }
+    case "selectRecord": {
+      const record = state.library.records.find((r) => r.id === action.payload.id);
+      return {
+        editor: {
+          ...state.editor,
+          selectedType: record?.type ?? null,
+          draft: (record?.data as Record<string, unknown>) ?? null,
+          step: record ? 3 : 0,
+          validationErrors: [],
+          isValid: Boolean(record)
+        },
+        library: { ...state.library, selectedId: action.payload.id }
+      };
+    }
+    case "reset": {
+      return {
+        editor: initialEditor,
+        library: state.library
+      };
+    }
+    default:
+      return state;
+  }
+}
+
+export function AssetProvider({ children }: { children: ReactNode }) {
+  const existingRecords = loadLibrary();
+  const seedRecords =
+    existingRecords.length === 0
+      ? [createRecord("monsterStat", defaultMonsterStat)]
+      : existingRecords;
+
+  const [state, dispatch] = useReducer(reducer, {
+    editor: initialEditor,
+    library: { ...initialLibrary, records: seedRecords }
+  });
+
+  useEffect(() => {
+    persistLibrary(state.library.records);
+  }, [state.library.records]);
+
+  const value = useMemo(() => ({ state, dispatch }), [state]);
+
+  return <AssetContext.Provider value={value}>{children}</AssetContext.Provider>;
+}
+
+export function useAssetContext() {
+  const context = useContext(AssetContext);
+  if (!context) {
+    throw new Error("useAssetContext must be used within AssetProvider");
+  }
+  return context;
+}
+
+export function createRecord(type: AssetType, data: Record<string, unknown>): AssetRecord {
+  const now = new Date().toISOString();
+  const normalizedData = JSON.parse(JSON.stringify(data));
+  return {
+    id: typeof data.id === "string" ? data.id : generateId(),
+    type,
+    data: normalizedData,
+    createdAt: now,
+    updatedAt: now
+  };
+}

--- a/ashes-asset-studio/src/context/types.ts
+++ b/ashes-asset-studio/src/context/types.ts
@@ -1,0 +1,63 @@
+import { JSONSchemaType } from "ajv";
+import { AssetType } from "../schemas/types";
+
+export type EditorMode = "form" | "json";
+
+export interface ValidationIssue {
+  field: string;
+  message: string;
+}
+
+export type AssetDataMap = Record<AssetType, unknown>;
+
+export interface AssetRecord<T extends AssetType = AssetType> {
+  id: string;
+  type: T;
+  data: AssetDataMap[T];
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface EditorState {
+  step: 0 | 1 | 2 | 3 | 4;
+  selectedType: AssetType | null;
+  mode: EditorMode;
+  draft: Record<string, unknown> | null;
+  jsonDraft: string;
+  validationErrors: ValidationIssue[];
+  isValid: boolean;
+}
+
+export interface LibraryState {
+  records: AssetRecord[];
+  filters: {
+    search: string;
+    types: AssetType[];
+    sort: "updatedDesc" | "updatedAsc" | "nameAsc" | "nameDesc";
+  };
+  selectedId: string | null;
+}
+
+export type AssetAction =
+  | { type: "setType"; payload: { type: AssetType } }
+  | { type: "setMode"; payload: { mode: EditorMode } }
+  | { type: "setStep"; payload: { step: EditorState["step"] } }
+  | {
+      type: "updateDraft";
+      payload: { name: string; value: unknown };
+    }
+  | { type: "setDraft"; payload: { draft: Record<string, unknown> | null } }
+  | { type: "setJsonDraft"; payload: { value: string } }
+  | {
+      type: "setValidation";
+      payload: { issues: ValidationIssue[]; valid: boolean };
+    }
+  | { type: "reset" }
+  | { type: "addRecord"; payload: { record: AssetRecord } }
+  | { type: "selectRecord"; payload: { id: string | null } };
+
+export interface SchemaEntry<T = unknown> {
+  id: string;
+  title: string;
+  schema: JSONSchemaType<T> | Record<string, unknown>;
+}

--- a/ashes-asset-studio/src/context/useAsset.ts
+++ b/ashes-asset-studio/src/context/useAsset.ts
@@ -1,0 +1,5 @@
+import { useAssetContext } from "./AssetContext";
+
+export function useAsset() {
+  return useAssetContext();
+}

--- a/ashes-asset-studio/src/data/defaultAssets.ts
+++ b/ashes-asset-studio/src/data/defaultAssets.ts
@@ -1,0 +1,15 @@
+export const defaultMonsterStat = {
+  id: "11111111-1111-1111-1111-111111111111",
+  name: "Carrion Warpriest",
+  rarityTag: "elite",
+  category: "undead",
+  type: "elite",
+  hp: 18,
+  dmg: 6,
+  spd: 3,
+  traits: ["Aura of Rot", "Ash-Touched"],
+  xp: 3,
+  gold: 12,
+  threatValue: 4,
+  lootValue: 2
+};

--- a/ashes-asset-studio/src/main.tsx
+++ b/ashes-asset-studio/src/main.tsx
@@ -1,0 +1,10 @@
+import React from "react";
+import ReactDOM from "react-dom/client";
+import App from "./App";
+import "./styles/tailwind.css";
+
+ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/ashes-asset-studio/src/schemas/ash.schema.json
+++ b/ashes-asset-studio/src/schemas/ash.schema.json
@@ -1,0 +1,25 @@
+{
+  "$id": "https://ashesofverdun.app/schemas/ash.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["id", "tiers"],
+  "properties": {
+    "id": { "type": "string", "format": "uuid" },
+    "tiers": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["threshold", "boon", "drawback"],
+        "properties": {
+          "threshold": { "type": "integer", "enum": [1, 3, 5] },
+          "boon": { "type": "string", "minLength": 1 },
+          "drawback": { "type": "string", "minLength": 1 }
+        }
+      }
+    },
+    "monsterSurge": { "type": ["string", "null"] }
+  }
+}

--- a/ashes-asset-studio/src/schemas/burden.schema.json
+++ b/ashes-asset-studio/src/schemas/burden.schema.json
@@ -1,0 +1,15 @@
+{
+  "$id": "https://ashesofverdun.app/schemas/burden.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["id", "kind", "name", "effect"],
+  "properties": {
+    "id": { "type": "string", "format": "uuid" },
+    "kind": { "type": "string", "enum": ["affliction", "virtue"] },
+    "name": { "type": "string", "minLength": 1 },
+    "effect": { "type": "string", "minLength": 1 },
+    "partyRipple": { "type": ["string", "null"] },
+    "roleplayLine": { "type": ["string", "null"] }
+  }
+}

--- a/ashes-asset-studio/src/schemas/consumable.schema.json
+++ b/ashes-asset-studio/src/schemas/consumable.schema.json
@@ -1,0 +1,15 @@
+{
+  "$id": "https://ashesofverdun.app/schemas/consumable.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["id", "name", "uses", "effect"],
+  "properties": {
+    "id": { "type": "string", "format": "uuid" },
+    "name": { "type": "string", "minLength": 1 },
+    "uses": { "type": "integer", "minimum": 1 },
+    "effect": { "type": "string", "minLength": 1 },
+    "limitPerRound": { "type": ["integer", "null"], "minimum": 1 },
+    "afterEffect": { "type": ["string", "null"] }
+  }
+}

--- a/ashes-asset-studio/src/schemas/equipment.schema.json
+++ b/ashes-asset-studio/src/schemas/equipment.schema.json
@@ -1,0 +1,37 @@
+{
+  "$id": "https://ashesofverdun.app/schemas/equipment.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["id", "slot", "name", "effects", "drawbacks", "rarity"],
+  "properties": {
+    "id": { "type": "string", "format": "uuid" },
+    "slot": {
+      "type": "string",
+      "enum": [
+        "weapon1H",
+        "offhand",
+        "weapon2H",
+        "armorBody",
+        "armorOther",
+        "talismanRelic"
+      ]
+    },
+    "name": { "type": "string", "minLength": 1 },
+    "effects": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 },
+      "minItems": 1
+    },
+    "drawbacks": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "charges": { "type": ["integer", "null"], "minimum": 0 },
+    "rarity": {
+      "type": "string",
+      "enum": ["mundane", "scarce", "rare", "epic", "mythic"]
+    },
+    "notes": { "type": ["string", "null"] }
+  }
+}

--- a/ashes-asset-studio/src/schemas/heroAbility.schema.json
+++ b/ashes-asset-studio/src/schemas/heroAbility.schema.json
@@ -1,0 +1,60 @@
+{
+  "$id": "https://ashesofverdun.app/schemas/heroAbility.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "id",
+    "class",
+    "abilityName",
+    "level",
+    "range",
+    "timing",
+    "type",
+    "skillActions",
+    "successOutcomes"
+  ],
+  "properties": {
+    "id": { "type": "string", "format": "uuid" },
+    "class": { "type": "string", "minLength": 1 },
+    "abilityName": { "type": "string", "minLength": 1 },
+    "level": { "type": "integer", "minimum": 1, "maximum": 3 },
+    "range": { "type": "string", "minLength": 1 },
+    "timing": {
+      "type": "string",
+      "enum": ["turnStart", "turnEnd", "reaction", "interrupt", "bonus"]
+    },
+    "type": {
+      "type": "string",
+      "enum": ["melee", "ranged", "aoe", "support", "utility"]
+    },
+    "skillActions": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 },
+      "minItems": 1
+    },
+    "successOutcomes": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 },
+      "minItems": 1
+    },
+    "critical": { "type": ["string", "null"] },
+    "bonusOutcome": { "type": ["string", "null"] },
+    "gigaFail": { "type": ["string", "null"] },
+    "costs": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": [
+          "hp",
+          "burden",
+          "status",
+          "selfStagger",
+          "consumeAsh",
+          "loseInitiative"
+        ]
+      },
+      "minItems": 0
+    }
+  }
+}

--- a/ashes-asset-studio/src/schemas/index.ts
+++ b/ashes-asset-studio/src/schemas/index.ts
@@ -1,0 +1,20 @@
+import monsterStatSchema from "./monsterStat.schema.json";
+import monsterAbilitySchema from "./monsterAbility.schema.json";
+import heroAbilitySchema from "./heroAbility.schema.json";
+import equipmentSchema from "./equipment.schema.json";
+import consumableSchema from "./consumable.schema.json";
+import burdenSchema from "./burden.schema.json";
+import ashSchema from "./ash.schema.json";
+import { AssetType } from "./types";
+
+export const schemaMap = {
+  monsterStat: monsterStatSchema,
+  monsterAbility: monsterAbilitySchema,
+  heroAbility: heroAbilitySchema,
+  equipment: equipmentSchema,
+  consumable: consumableSchema,
+  burden: burdenSchema,
+  ash: ashSchema
+} satisfies Record<AssetType, unknown>;
+
+export type SchemaKey = keyof typeof schemaMap;

--- a/ashes-asset-studio/src/schemas/monsterAbility.schema.json
+++ b/ashes-asset-studio/src/schemas/monsterAbility.schema.json
@@ -1,0 +1,38 @@
+{
+  "$id": "https://ashesofverdun.app/schemas/monsterAbility.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "id",
+    "monsterName",
+    "attackName",
+    "initiative",
+    "actions",
+    "targets"
+  ],
+  "properties": {
+    "id": { "type": "string", "format": "uuid" },
+    "monsterName": { "type": "string", "minLength": 1 },
+    "attackName": { "type": "string", "minLength": 1 },
+    "initiative": { "type": "integer", "minimum": 0, "maximum": 10 },
+    "actions": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "targets": {
+      "type": "string",
+      "enum": [
+        "nearest",
+        "highestBurden",
+        "lowestHP",
+        "furthest",
+        "random",
+        "focusFire"
+      ]
+    },
+    "ashSurge": { "type": ["string", "null"] },
+    "flavor": { "type": ["string", "null"] }
+  }
+}

--- a/ashes-asset-studio/src/schemas/monsterStat.schema.json
+++ b/ashes-asset-studio/src/schemas/monsterStat.schema.json
@@ -1,0 +1,77 @@
+{
+  "$id": "https://ashesofverdun.app/schemas/monsterStat.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "id",
+    "name",
+    "rarityTag",
+    "category",
+    "type",
+    "hp",
+    "dmg",
+    "spd",
+    "traits",
+    "xp",
+    "gold",
+    "threatValue",
+    "lootValue"
+  ],
+  "properties": {
+    "id": { "type": "string", "format": "uuid" },
+    "name": { "type": "string", "minLength": 1 },
+    "rarityTag": {
+      "type": "string",
+      "enum": ["common", "elite", "boss", "legendary"]
+    },
+    "category": {
+      "type": "string",
+      "enum": ["undead", "aberration", "wretched", "eldritch", "feral", "construct"]
+    },
+    "type": { "type": "string", "enum": ["minion", "elite", "boss"] },
+    "hp": { "type": "integer", "minimum": 1 },
+    "dmg": { "type": "integer", "minimum": 0 },
+    "spd": { "type": "integer", "minimum": 0 },
+    "traits": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 },
+      "minItems": 0,
+      "maxItems": 6
+    },
+    "xp": { "type": "integer", "minimum": 0 },
+    "gold": { "type": "integer", "minimum": 0 },
+    "threatValue": { "type": "integer", "minimum": 0 },
+    "lootValue": { "type": "integer", "minimum": 0 },
+    "portraitUrl": { "type": ["string", "null"], "format": "uri" },
+    "scaling": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "normal": { "$ref": "#/$defs/scalingBlock" },
+        "elite": { "$ref": "#/$defs/scalingBlock" }
+      }
+    }
+  },
+  "$defs": {
+    "scalingRow": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["hp", "dmg", "spd"],
+      "properties": {
+        "hp": { "type": "integer", "minimum": 0 },
+        "dmg": { "type": "integer", "minimum": 0 },
+        "spd": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "scalingBlock": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "lv1": { "$ref": "#/$defs/scalingRow" },
+        "lv2": { "$ref": "#/$defs/scalingRow" },
+        "lv3": { "$ref": "#/$defs/scalingRow" }
+      }
+    }
+  }
+}

--- a/ashes-asset-studio/src/schemas/types.ts
+++ b/ashes-asset-studio/src/schemas/types.ts
@@ -1,0 +1,41 @@
+export type AssetType =
+  | "monsterStat"
+  | "monsterAbility"
+  | "heroAbility"
+  | "equipment"
+  | "consumable"
+  | "burden"
+  | "ash";
+
+export interface MonsterStatScalingRow {
+  hp: number;
+  dmg: number;
+  spd: number;
+}
+
+export interface MonsterStatScalingBlock {
+  lv1?: MonsterStatScalingRow;
+  lv2?: MonsterStatScalingRow;
+  lv3?: MonsterStatScalingRow;
+}
+
+export interface MonsterStatCard {
+  id: string;
+  name: string;
+  rarityTag: "common" | "elite" | "boss" | "legendary";
+  category: "undead" | "aberration" | "wretched" | "eldritch" | "feral" | "construct";
+  type: "minion" | "elite" | "boss";
+  hp: number;
+  dmg: number;
+  spd: number;
+  traits: string[];
+  xp: number;
+  gold: number;
+  threatValue: number;
+  lootValue: number;
+  portraitUrl?: string | null;
+  scaling?: {
+    normal?: MonsterStatScalingBlock;
+    elite?: MonsterStatScalingBlock;
+  };
+}

--- a/ashes-asset-studio/src/styles/tailwind.css
+++ b/ashes-asset-studio/src/styles/tailwind.css
@@ -1,0 +1,15 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  color-scheme: dark;
+}
+
+body {
+  @apply bg-slate-950 text-slate-100 font-body;
+}
+
+::selection {
+  @apply bg-amber-500/50 text-slate-900;
+}

--- a/ashes-asset-studio/src/utils/ajv.ts
+++ b/ashes-asset-studio/src/utils/ajv.ts
@@ -1,0 +1,39 @@
+import Ajv from "ajv";
+import addFormats from "ajv-formats";
+import { schemaMap } from "../schemas";
+import { AssetType } from "../schemas/types";
+
+const ajv = new Ajv({
+  allErrors: true,
+  strict: true,
+  removeAdditional: false,
+  messages: true
+});
+
+addFormats(ajv);
+
+export const validators: Record<AssetType, ReturnType<typeof ajv.compile>> =
+  Object.entries(schemaMap).reduce((acc, [key, schema]) => {
+    acc[key as AssetType] = ajv.compile(schema);
+    return acc;
+  }, {} as Record<AssetType, ReturnType<typeof ajv.compile>>);
+
+export type ValidationResult = {
+  valid: boolean;
+  issues: { field: string; message: string }[];
+};
+
+export function validateAsset(type: AssetType, value: unknown): ValidationResult {
+  const validator = validators[type];
+  const valid = validator(value);
+  if (valid) {
+    return { valid: true, issues: [] };
+  }
+
+  const issues = (validator.errors ?? []).map((err) => ({
+    field: err.instancePath ? err.instancePath.replace(/^\//, "") : err.params.missingProperty ?? "root",
+    message: err.message ?? "Invalid"
+  }));
+
+  return { valid: false, issues };
+}

--- a/ashes-asset-studio/src/utils/formConfig.ts
+++ b/ashes-asset-studio/src/utils/formConfig.ts
@@ -1,0 +1,123 @@
+import { AssetType } from "../schemas/types";
+
+type BaseField = {
+  name: string;
+  label: string;
+  placeholder?: string;
+  help?: string;
+  transform?: (value: string) => unknown;
+};
+
+type TextField = BaseField & {
+  input: "text" | "number" | "textarea";
+};
+
+type SelectField = BaseField & {
+  input: "select";
+  options: { label: string; value: string }[];
+};
+
+type FieldConfig = TextField | SelectField;
+
+const monsterStatFields: FieldConfig[] = [
+  {
+    name: "name",
+    label: "Monster Name",
+    input: "text",
+    placeholder: "Carrion Warpriest"
+  },
+  {
+    name: "rarityTag",
+    label: "Rarity",
+    input: "select",
+    options: [
+      { label: "Common", value: "common" },
+      { label: "Elite", value: "elite" },
+      { label: "Boss", value: "boss" },
+      { label: "Legendary", value: "legendary" }
+    ]
+  },
+  {
+    name: "category",
+    label: "Category",
+    input: "select",
+    options: [
+      { label: "Undead", value: "undead" },
+      { label: "Aberration", value: "aberration" },
+      { label: "Wretched", value: "wretched" },
+      { label: "Eldritch", value: "eldritch" },
+      { label: "Feral", value: "feral" },
+      { label: "Construct", value: "construct" }
+    ]
+  },
+  {
+    name: "type",
+    label: "Role",
+    input: "select",
+    options: [
+      { label: "Minion", value: "minion" },
+      { label: "Elite", value: "elite" },
+      { label: "Boss", value: "boss" }
+    ]
+  },
+  {
+    name: "hp",
+    label: "Health",
+    input: "number",
+    placeholder: "18"
+  },
+  {
+    name: "dmg",
+    label: "Damage",
+    input: "number",
+    placeholder: "6"
+  },
+  {
+    name: "spd",
+    label: "Speed",
+    input: "number",
+    placeholder: "3"
+  },
+  {
+    name: "traits",
+    label: "Traits",
+    input: "textarea",
+    placeholder: "Aura of Rot\nAsh-Touched",
+    help: "One trait per line; converted into list values.",
+    transform: (value: string) =>
+      value
+        .split(/\r?\n/)
+        .map((line) => line.trim())
+        .filter(Boolean)
+  },
+  {
+    name: "xp",
+    label: "XP",
+    input: "number",
+    placeholder: "2"
+  },
+  {
+    name: "gold",
+    label: "Gold",
+    input: "number",
+    placeholder: "8"
+  },
+  {
+    name: "threatValue",
+    label: "Threat Value",
+    input: "number",
+    placeholder: "3"
+  },
+  {
+    name: "lootValue",
+    label: "Loot Value",
+    input: "number",
+    placeholder: "2"
+  }
+];
+
+export const fieldConfigMap: Partial<Record<AssetType, FieldConfig[]>> = {
+  monsterStat: monsterStatFields
+};
+
+export type { FieldConfig };

--- a/ashes-asset-studio/src/utils/storage.ts
+++ b/ashes-asset-studio/src/utils/storage.ts
@@ -1,0 +1,31 @@
+import { AssetRecord } from "../context/types";
+
+const STORAGE_KEY = "ashes-of-verdun-asset-library";
+
+export function loadLibrary(): AssetRecord[] {
+  if (typeof window === "undefined") {
+    return [];
+  }
+
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    const data = JSON.parse(raw) as AssetRecord[];
+    return Array.isArray(data) ? data : [];
+  } catch (error) {
+    console.error("Failed to parse library", error);
+    return [];
+  }
+}
+
+export function persistLibrary(records: AssetRecord[]): void {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(records));
+  } catch (error) {
+    console.error("Failed to persist library", error);
+  }
+}

--- a/ashes-asset-studio/tailwind.config.cjs
+++ b/ashes-asset-studio/tailwind.config.cjs
@@ -1,0 +1,28 @@
+const defaultTheme = require("tailwindcss/defaultTheme");
+
+module.exports = {
+  content: ["./index.html", "./src/**/*.{ts,tsx}"],
+  theme: {
+    extend: {
+      fontFamily: {
+        display: ["'Cinzel'", ...defaultTheme.fontFamily.serif],
+        body: ["'Inter'", ...defaultTheme.fontFamily.sans]
+      },
+      colors: {
+        ash: {
+          50: "#f7f5f2",
+          100: "#e4ded7",
+          200: "#cfc2b3",
+          300: "#bba68f",
+          400: "#a98d6d",
+          500: "#8f7253",
+          600: "#725940",
+          700: "#564131",
+          800: "#3a2b20",
+          900: "#1f1711"
+        }
+      }
+    }
+  },
+  plugins: []
+};

--- a/ashes-asset-studio/tsconfig.json
+++ b/ashes-asset-studio/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ES2020"],
+    "module": "ESNext",
+    "skipLibCheck": false,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "types": ["vite/client"]
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/ashes-asset-studio/tsconfig.node.json
+++ b/ashes-asset-studio/tsconfig.node.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/ashes-asset-studio/vite.config.ts
+++ b/ashes-asset-studio/vite.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173,
+    host: true
+  }
+});


### PR DESCRIPTION
## Summary
- initialize a Vite + React + TypeScript project with Tailwind and linting configuration for the Asset Studio
- define AJV-compatible JSON schemas for every Ashes of Verdun asset type and seed a default monster stat card
- implement core UI scaffolding including type selection, mode switching, dynamic form/JSON validation flow, library panel, and themed preview frame

## Testing
- not run (dependencies not installed in offline environment)


------
https://chatgpt.com/codex/tasks/task_e_68dec0ea5274832195d998fe74a87cfb